### PR TITLE
Fix duplicated 'how much' in softmax explanation

### DIFF
--- a/_posts/2018-06-27-illustrated-transformer.md
+++ b/_posts/2018-06-27-illustrated-transformer.md
@@ -181,7 +181,7 @@ The **third and forth steps** are to divide the scores by 8 (the square root of 
 
 </div>
 
-This softmax score determines how much how much each word will be expressed at this position. Clearly the word at this position will have the highest softmax score, but sometimes it's useful to attend to another word that is relevant to the current word.
+This softmax score determines how much each word will be expressed at this position. Clearly the word at this position will have the highest softmax score, but sometimes it's useful to attend to another word that is relevant to the current word.
 
 <br />
 


### PR DESCRIPTION
Small grammar fix in the ''Illustrated Transformer' article. @jalammar 
![image](https://user-images.githubusercontent.com/8587189/61045800-4d450b00-a3fb-11e9-808c-ed456bca1650.png)
