### PR TITLE
Remove ambiguity + fix typo

### DIFF
--- a/_posts/2018-06-27-illustrated-transformer.md
+++ b/_posts/2018-06-27-illustrated-transformer.md
@@ -235,7 +235,7 @@ That concludes the self-attention calculation. The resulting vector is one we ca
 
 The paper further refined the self-attention layer by adding a mechanism called "multi-headed" attention. This improves the performance of the attention layer in two ways:
 
- 1. It expands the model's ability to focus on different positions. Yes, in the example above, z1 contains a little bit of every other encoding, but it could be dominated by the the actual word itself. It would be useful if we're translating a sentence like "The animal didn't cross the street because it was too tired", we would want to know which word "it" refers to.
+ 1. It expands the model's ability to focus on different positions. Yes, in the example above, z1 contains a little bit of every other encoding, but it could be dominated by the actual word itself. If we're translating a sentence like "The animal didn't cross the street because it was too tired", it would be useful to know which word "it" refers to.
 
  1. It gives the attention layer multiple "representation subspaces". As we'll see next, with multi-headed attention we have not only one, but multiple sets of Query/Key/Value weight matrices (the Transformer uses eight attention heads, so we end up with eight sets for each encoder/decoder). Each of these sets is randomly initialized. Then, after training, each set is used to project the input embeddings (or vectors from lower encoders/decoders) into a different representation subspace.
 


### PR DESCRIPTION
The sentence "Yes, in the example above, z1 contains a little bit of every other encoding, but it could be dominated by the the actual word itself. It would be useful if we’re translating a sentence like “The animal didn’t cross the street because it was too tired”, we would want to know which word “it” refers to." has a minor spelling mistake (repeated "the") but also is ambiguous because it could be thought to mean "it would be useful, [domination by the word itself] if ..." while instead you are trying to say "it would be useful to know which word "it" refers to in the example "The animal didn't cross the street because it was too tired"" In it's current form it is ambiguous but there are many ways of fixing it :)