### PR TITLE
Fixed error in KV cache text in Illustrated GPT2

### DIFF
--- a/_posts/2019-08-12-illustrated-gpt2.md
+++ b/_posts/2019-08-12-illustrated-gpt2.md
@@ -486,7 +486,7 @@ GPT-2 holds on to the key and value vectors of the the ```a``` token. Every self
   <br />
 </div>
 
-Now in the next iteration, when the model processes the word ```robot```, it does not need to generate query, key, and value queries for the ```a``` token. It just reuses the ones it saved from the first iteration:
+Now in the next iteration, when the model processes the word ```robot```, it does not need to regenerate the key, and value vectors for the ```a``` token. It just reuses the ones it saved from the first iteration:
 
 <div class="img-div-any-width" markdown="0">
   <image src="/images/gpt2/gpt2-self-attention-qkv-3-2.png"/>


### PR DESCRIPTION
I think the saving and reuse of K, V across tokens does not include Q. (I'm definitely not an expert, please correct me if I'm wrong.)