### PR TITLE
Fix "Torch" missing in notebook Simple_Transformer_Language_Model.ipynb

### DIFF
--- a/notebooks/Simple_Transformer_Language_Model.ipynb
+++ b/notebooks/Simple_Transformer_Language_Model.ipynb
@@ -37,7 +37,7 @@
         "outputId": "45caa369-4bda-420d-f407-1002204c6e83"
       },
       "source": [
-        "!pip install transformers",
+        "!pip install transformers\n",
         "!pip install torch"
       ],
       "execution_count": 103,

--- a/notebooks/Simple_Transformer_Language_Model.ipynb
+++ b/notebooks/Simple_Transformer_Language_Model.ipynb
@@ -280,7 +280,7 @@
       },
       "source": [
         "# Get the embedding vector of token # 464 ('The')\n",
-        "import torch"
+        "import torch",
         "model.transformer.wte(torch.tensor(464))"
       ],
       "execution_count": null,

--- a/notebooks/Simple_Transformer_Language_Model.ipynb
+++ b/notebooks/Simple_Transformer_Language_Model.ipynb
@@ -38,6 +38,7 @@
       },
       "source": [
         "!pip install transformers"
+        "!pip install torch"
       ],
       "execution_count": 103,
       "outputs": [
@@ -279,6 +280,7 @@
       },
       "source": [
         "# Get the embedding vector of token # 464 ('The')\n",
+        "import torch"
         "model.transformer.wte(torch.tensor(464))"
       ],
       "execution_count": null,

--- a/notebooks/Simple_Transformer_Language_Model.ipynb
+++ b/notebooks/Simple_Transformer_Language_Model.ipynb
@@ -37,7 +37,7 @@
         "outputId": "45caa369-4bda-420d-f407-1002204c6e83"
       },
       "source": [
-        "!pip install transformers"
+        "!pip install transformers",
         "!pip install torch"
       ],
       "execution_count": 103,


### PR DESCRIPTION
As of today, Torch is not installed nor imported in "!pip install transformers" therefore, we need to add it in order to run the notebook till the end.